### PR TITLE
Security: Dependabot findings.

### DIFF
--- a/.github/workflows/build.from.developer.branch.deploy.to.dev.yml
+++ b/.github/workflows/build.from.developer.branch.deploy.to.dev.yml
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.choice }}
 
@@ -64,7 +64,7 @@ jobs:
           echo "TAG=latest ${GITHUB_SHA::12}" | tee -a $GITHUB_ENV
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ vars.DOCKER_ARTIFACTORY_REPO }}
           username: ${{ vars.DOCKER_ARTIFACTORY_USERNAME }}

--- a/.github/workflows/build.from.main.branch.deploy.to.dev.yml
+++ b/.github/workflows/build.from.main.branch.deploy.to.dev.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Determine image tags
         if: env.TAG == ''
@@ -50,7 +50,7 @@ jobs:
           echo "TAG=latest ${GITHUB_SHA::12}" | tee -a $GITHUB_ENV
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ vars.DOCKER_ARTIFACTORY_REPO }}
           username: ${{ vars.DOCKER_ARTIFACTORY_USERNAME }}

--- a/.github/workflows/build.from.release.branch.deploy.to.dev.yml
+++ b/.github/workflows/build.from.release.branch.deploy.to.dev.yml
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: grad-release
 
@@ -58,7 +58,7 @@ jobs:
           echo "TAG=latest ${GITHUB_SHA::12}" | tee -a $GITHUB_ENV
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ vars.DOCKER_ARTIFACTORY_REPO }}
           username: ${{ vars.DOCKER_ARTIFACTORY_USERNAME }}

--- a/.github/workflows/create_tag.yml
+++ b/.github/workflows/create_tag.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Create tag
         uses: actions/github-script@v7
@@ -54,7 +54,7 @@ jobs:
           oc: 4
 
         # https://github.com/redhat-actions/oc-login#readme
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Tag in OpenShift
         run: |
           set -eux

--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get latest tag
         uses: actions-ecosystem/action-get-latest-tag@v1

--- a/.github/workflows/deploy_test.yml
+++ b/.github/workflows/deploy_test.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get latest tag
         uses: actions-ecosystem/action-get-latest-tag@v1

--- a/.github/workflows/on.pr.yml
+++ b/.github/workflows/on.pr.yml
@@ -17,12 +17,13 @@ jobs:
         working-directory: api
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 18
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: 'corretto'
           java-version: 18
       - uses: actions/cache@v1
         with:

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -36,9 +36,9 @@
         <maven.compiler.version>3.10.1</maven.compiler.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
-        <log4j.version>2.18.0</log4j.version>
-        <org.mapstruct.version>1.5.2.Final</org.mapstruct.version>
-        <springdoc.version>1.6.9</springdoc.version>
+        <log4j.version>2.24.3</log4j.version>
+        <org.mapstruct.version>1.6.3</org.mapstruct.version>
+        <springdoc.version>1.6.11</springdoc.version>
         <junit>4.12</junit>
     </properties>
 
@@ -95,9 +95,9 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>com.oracle.jdbc</groupId>
-            <artifactId>ojdbc8</artifactId>
-            <version>12.2.0.1</version>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc11</artifactId>
+            <version>21.3.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.springdoc</groupId>
@@ -161,7 +161,7 @@
         <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
-            <version>8.5.13</version>
+            <version>11.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.vintage</groupId>
@@ -202,7 +202,7 @@
                 <plugin>
                     <groupId>org.hibernate.orm.tooling</groupId>
                     <artifactId>hibernate-enhance-maven-plugin</artifactId>
-                    <version>6.1.1.Final</version>
+                    <version>6.6.5.Final</version>
                 </plugin>
                 <plugin>
                     <groupId>org.springframework.boot</groupId>
@@ -286,7 +286,7 @@
                     <plugin>
                         <groupId>org.hibernate.orm.tooling</groupId>
                         <artifactId>hibernate-enhance-maven-plugin</artifactId>
-                        <version>6.1.1.Final</version>
+                        <version>6.6.5.Final</version>
                         <executions>
                             <execution>
                                 <configuration>


### PR DESCRIPTION

Change Details:

- Bump org.hibernate.orm.tooling:hibernate-enhance-maven-plugin from 6.1.1.Final to 6.6.5.Final  
- Bump org.flywaydb:flyway-core from 8.5.13 to 11.2.0  
- Bump org.apache.logging.log4j:log4j-to-slf4j from 2.18.0 to 2.24.3  
- Bump actions/checkout from 2 to 4 
- Bump docker/login-action from 2 to 3 
- Bump actions/setup-java from 1 to 4 
- Bump springdoc.version from 1.6.9 to 1.6.11  
- Upgrade ojdbc8 to ojdbc11
- Bump org.mapstruct.version from 1.5.2.Final to 1.6.3